### PR TITLE
user_data.tftpl updated

### DIFF
--- a/user_data.tftpl
+++ b/user_data.tftpl
@@ -4,6 +4,7 @@
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
 sudo apt-get -y -qq install curl wget git vim apt-transport-https ca-certificates
 sudo add-apt-repository ppa:longsleep/golang-backports -y
+sudo apt-get update
 sudo apt -y -qq install golang-go
 
 # Setup sudo to allow no-password sudo for your group and adding your user


### PR DESCRIPTION
the bash script fails to install go without the additional line (as a result the webapp won't run and the instance seems to be not accessible via public_ip:8080)